### PR TITLE
Fix game->raiseSize init and typo in reading raiseSize config.

### DIFF
--- a/project_acpc_server/game.cc
+++ b/project_acpc_server/game.cc
@@ -169,6 +169,9 @@ Game *readGame( FILE *file )
   }
   blindRead = 0;
   raiseSizeRead = 0;
+  for( c = 0; c < MAX_ROUNDS; ++c ) {
+    game->raiseSize[ c ] = INT32_MAX;
+  }
   game->bettingType = limitBetting;
   game->numPlayers = 0;
   game->numRounds = 0;
@@ -205,7 +208,7 @@ Game *readGame( FILE *file )
 			     1, game->blind, 4, &c );
     } else if( !strncasecmp( line, "raisesize", 9 ) ) {
 
-      raiseSizeRead = readItems( "%" SCNd32, MAX_PLAYERS, &line[ 9 ],
+      raiseSizeRead = readItems( "%" SCNd32, MAX_ROUNDS, &line[ 9 ],
 				 1, game->raiseSize, 4, &c );
     } else if( !strncasecmp( line, "limit", 5 ) ) {
 


### PR DESCRIPTION
Adding the `game->raiseSize` init was needed in order to fix `universal_poker_test.cc` in `DeepMind/open_spiel`.

Without this init, I receive this test error:
```
Spiel Fatal Error: /home/ubuntu/open_spiel/open_spiel/games/universal_poker_test.cc:108 CHECK_TRUE((*(holdem_no_limit_6p_gamedef.GetACPCGame())) == (*(holdem_no_limit_6p.GetACPCGame())))
```

And inspecting `game->raiseSize[0]` shows these two values for those two games (which didn’t specify any `raiseSizes`), which to me looked like it might be reading from uninitialized memory:
```
raiseSizes
15247248
0
```